### PR TITLE
Polyfill async/await for old browsers

### DIFF
--- a/assets/js/colors.js
+++ b/assets/js/colors.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 window.githubColors = {
     "1C Enterprise": {
         "color": "#814CCC",

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 const colors = window.githubColors;
 
 let oldUser = "";

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 // CONVERTS SVGS WHICH ARE IN IMG TAGS TO NORMAL SVGS
 $(function () {
     $('img.svg').each(function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,6 +555,25 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/DeliriumProducts/gh-favlang#readme",
   "devDependencies": {
     "babel-core": "^6.26.3",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "cssnano": "^4.0.3"
   }


### PR DESCRIPTION
It's too bad I had to `import "babel-polyfill";` three times, but that's how many files are entrypoints, so it was unavoidable.